### PR TITLE
Add project file enumeration helper and CLI test

### DIFF
--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -18,7 +18,7 @@ if (args[0].Equals("scan", StringComparison.OrdinalIgnoreCase))
     }
 
     var manager = new ProjectManager();
-    var projectFiles = Directory.GetFiles(path, "*.csproj", SearchOption.AllDirectories);
+    var projectFiles = manager.EnumerateProjectFiles(path);
     foreach (var projectFile in projectFiles)
     {
         var project = await manager.LoadProjectAsync(projectFile);

--- a/src/DeveloperGeniue.Core/ProjectManager.cs
+++ b/src/DeveloperGeniue.Core/ProjectManager.cs
@@ -81,4 +81,21 @@ public class ProjectManager : IProjectManager
             _ => CodeFileType.Other
         };
     }
+
+    public IEnumerable<string> EnumerateProjectFiles(string rootPath)
+    {
+        var files = Directory.EnumerateFiles(rootPath, "*.csproj", SearchOption.AllDirectories);
+        foreach (var file in files)
+        {
+            if (!IsInIgnoredDirectory(file))
+                yield return file;
+        }
+    }
+
+    private static bool IsInIgnoredDirectory(string path)
+    {
+        var segments = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return segments.Any(s => s.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                             || s.Equals("obj", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/tests/DeveloperGeniue.Tests/CliScanTests.cs
+++ b/tests/DeveloperGeniue.Tests/CliScanTests.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using DeveloperGeniue.Core;
+
+namespace DeveloperGeniue.Tests;
+
+public class CliScanTests
+{
+    [Fact]
+    public async Task ScanExcludesBinAndObjDirectories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var csprojContent = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>";
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "Valid.csproj"), csprojContent);
+        Directory.CreateDirectory(Path.Combine(tempDir, "bin"));
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "bin", "Skip.csproj"), csprojContent);
+        Directory.CreateDirectory(Path.Combine(tempDir, "obj"));
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "obj", "Skip2.csproj"), csprojContent);
+
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var cliProj = Path.Combine(repoRoot, "src", "DeveloperGeniue.CLI", "DeveloperGeniue.CLI.csproj");
+
+        var psi = new ProcessStartInfo("dotnet", $"run --project \"{cliProj}\" -- scan \"{tempDir}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = repoRoot
+        };
+
+        using var proc = Process.Start(psi)!;
+        string output = await proc.StandardOutput.ReadToEndAsync();
+        await proc.WaitForExitAsync();
+
+        Directory.Delete(tempDir, true);
+
+        Assert.Contains("Valid", output);
+        Assert.DoesNotContain("Skip", output);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EnumerateProjectFiles` helper that skips `bin` and `obj`
- use helper in CLI scan command
- test that the CLI ignores projects inside `bin` and `obj`

## Testing
- `dotnet test DeveloperGeniue.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684be9b69bc08332a4106ee7b4af6584