### PR TITLE
Add build and test managers with CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ You can provide a path to scan a specific folder:
 dotnet run --project src/DeveloperGeniue.CLI -- scan ../some/path
 ```
 
+### Build a project
+
+Run `dotnet build` through the CLI:
+
+```bash
+dotnet run --project src/DeveloperGeniue.CLI -- build path/to/project.csproj
+```
+
+### Run tests
+
+Execute `dotnet test` on a project:
+
+```bash
+dotnet run --project src/DeveloperGeniue.CLI -- test path/to/project.csproj
+```
+
 ## Repository Structure
 
 ```

--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -5,6 +5,8 @@ if (args.Length == 0 || args[0].Equals("--help", StringComparison.OrdinalIgnoreC
     Console.WriteLine("DeveloperGeniue CLI");
     Console.WriteLine("Commands:");
     Console.WriteLine("  scan [path]   - Discover projects in the specified path");
+    Console.WriteLine("  build <csproj> - Build the specified project");
+    Console.WriteLine("  test <csproj>  - Run tests for the specified project");
     return;
 }
 
@@ -24,6 +26,38 @@ if (args[0].Equals("scan", StringComparison.OrdinalIgnoreCase))
         var project = await manager.LoadProjectAsync(projectFile);
         Console.WriteLine($"{project.Name} - {project.Framework} - {project.Type}");
     }
+    return;
+}
+
+if (args[0].Equals("build", StringComparison.OrdinalIgnoreCase))
+{
+    if (args.Length < 2)
+    {
+        Console.WriteLine("Project file required.");
+        return;
+    }
+
+    var manager = new BuildManager();
+    var result = await manager.BuildProjectAsync(args[1]);
+    Console.WriteLine(result.Output);
+    if (!string.IsNullOrWhiteSpace(result.Errors))
+        Console.WriteLine(result.Errors);
+    Environment.ExitCode = result.ExitCode;
+    return;
+}
+
+if (args[0].Equals("test", StringComparison.OrdinalIgnoreCase))
+{
+    if (args.Length < 2)
+    {
+        Console.WriteLine("Project file required.");
+        return;
+    }
+
+    var manager = new TestManager();
+    var result = await manager.RunTestsAsync(args[1]);
+    Console.WriteLine(result.Output);
+    Environment.ExitCode = result.Success ? 0 : 1;
     return;
 }
 

--- a/src/DeveloperGeniue.Core/BuildManager.cs
+++ b/src/DeveloperGeniue.Core/BuildManager.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace DeveloperGeniue.Core;
+
+public class BuildManager : IBuildManager
+{
+    public async Task<BuildResult> BuildProjectAsync(string projectPath)
+    {
+        var startTime = DateTime.UtcNow;
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"build \"{projectPath}\" --verbosity normal",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            }
+        };
+
+        var output = new StringBuilder();
+        var errors = new StringBuilder();
+
+        process.OutputDataReceived += (s, e) => { if (e.Data != null) output.AppendLine(e.Data); };
+        process.ErrorDataReceived += (s, e) => { if (e.Data != null) errors.AppendLine(e.Data); };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.WaitForExitAsync();
+
+        var duration = DateTime.UtcNow - startTime;
+
+        return new BuildResult
+        {
+            Success = process.ExitCode == 0,
+            Output = output.ToString(),
+            Errors = errors.ToString(),
+            Duration = duration,
+            ExitCode = process.ExitCode
+        };
+    }
+}

--- a/src/DeveloperGeniue.Core/BuildResult.cs
+++ b/src/DeveloperGeniue.Core/BuildResult.cs
@@ -1,0 +1,10 @@
+namespace DeveloperGeniue.Core;
+
+public class BuildResult
+{
+    public bool Success { get; set; }
+    public string Output { get; set; } = string.Empty;
+    public string Errors { get; set; } = string.Empty;
+    public TimeSpan Duration { get; set; }
+    public int ExitCode { get; set; }
+}

--- a/src/DeveloperGeniue.Core/IBuildManager.cs
+++ b/src/DeveloperGeniue.Core/IBuildManager.cs
@@ -1,0 +1,6 @@
+namespace DeveloperGeniue.Core;
+
+public interface IBuildManager
+{
+    Task<BuildResult> BuildProjectAsync(string projectPath);
+}

--- a/src/DeveloperGeniue.Core/ITestManager.cs
+++ b/src/DeveloperGeniue.Core/ITestManager.cs
@@ -1,0 +1,6 @@
+namespace DeveloperGeniue.Core;
+
+public interface ITestManager
+{
+    Task<TestResult> RunTestsAsync(string projectPath);
+}

--- a/src/DeveloperGeniue.Core/TestManager.cs
+++ b/src/DeveloperGeniue.Core/TestManager.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace DeveloperGeniue.Core;
+
+public class TestManager : ITestManager
+{
+    public async Task<TestResult> RunTestsAsync(string projectPath)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"test \"{projectPath}\" --logger:trx --collect:\"XPlat Code Coverage\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return ParseTestResults(output);
+    }
+
+    private static TestResult ParseTestResults(string output)
+    {
+        var result = new TestResult { Output = output };
+
+        var summary = Regex.Match(output, @"Failed:\s*(\d+),\s*Passed:\s*(\d+),\s*Skipped:\s*(\d+),\s*Total:\s*(\d+)");
+        if (summary.Success)
+        {
+            result.FailedTests = int.Parse(summary.Groups[1].Value);
+            result.PassedTests = int.Parse(summary.Groups[2].Value);
+            result.SkippedTests = int.Parse(summary.Groups[3].Value);
+            result.TotalTests = int.Parse(summary.Groups[4].Value);
+        }
+
+        var duration = Regex.Match(output, @"Test execution time: ([0-9.]+)");
+        if (duration.Success && double.TryParse(duration.Groups[1].Value, out var seconds))
+        {
+            result.Duration = TimeSpan.FromSeconds(seconds);
+        }
+
+        result.Success = output.Contains("Test Run Successful");
+        return result;
+    }
+}

--- a/src/DeveloperGeniue.Core/TestResult.cs
+++ b/src/DeveloperGeniue.Core/TestResult.cs
@@ -1,0 +1,12 @@
+namespace DeveloperGeniue.Core;
+
+public class TestResult
+{
+    public bool Success { get; set; }
+    public int TotalTests { get; set; }
+    public int PassedTests { get; set; }
+    public int FailedTests { get; set; }
+    public int SkippedTests { get; set; }
+    public TimeSpan Duration { get; set; }
+    public string Output { get; set; } = string.Empty;
+}

--- a/tests/DeveloperGeniue.Tests/BuildManagerTests.cs
+++ b/tests/DeveloperGeniue.Tests/BuildManagerTests.cs
@@ -1,0 +1,27 @@
+using DeveloperGeniue.Core;
+
+namespace DeveloperGeniue.Tests;
+
+public class BuildManagerTests
+{
+    [Fact]
+    public async Task BuildInvokesDotnet()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var fake = Path.Combine(tempDir, "dotnet");
+        await File.WriteAllTextAsync(fake, "#!/bin/sh\necho building $@\n");
+        System.Diagnostics.Process.Start("chmod", $"+x {fake}").WaitForExit();
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+
+        var bm = new BuildManager();
+        var result = await bm.BuildProjectAsync("proj.csproj");
+
+        Environment.SetEnvironmentVariable("PATH", oldPath);
+        Directory.Delete(tempDir, true);
+
+        Assert.True(result.Success);
+        Assert.Contains("build", result.Output);
+    }
+}

--- a/tests/DeveloperGeniue.Tests/TestManagerTests.cs
+++ b/tests/DeveloperGeniue.Tests/TestManagerTests.cs
@@ -1,0 +1,29 @@
+using DeveloperGeniue.Core;
+
+namespace DeveloperGeniue.Tests;
+
+public class TestManagerTests
+{
+    [Fact]
+    public async Task TestResultsAreParsed()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var fake = Path.Combine(tempDir, "dotnet");
+        var script = "#!/bin/sh\necho 'Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 1 ms'\necho 'Test Run Successful.'\necho 'Test execution time: 0.1'\n";
+        await File.WriteAllTextAsync(fake, script);
+        System.Diagnostics.Process.Start("chmod", $"+x {fake}").WaitForExit();
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+
+        var tm = new TestManager();
+        var result = await tm.RunTestsAsync("proj.csproj");
+
+        Environment.SetEnvironmentVariable("PATH", oldPath);
+        Directory.Delete(tempDir, true);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.TotalTests);
+        Assert.Equal(1, result.PassedTests);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IBuildManager` and `ITestManager` interfaces
- add `BuildManager` and `TestManager` using `dotnet` CLI
- extend CLI with `build` and `test` commands
- document the new commands
- add unit tests for the build and test managers

## Testing
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be9b7710c83328921dba4dbbfeb1d