### PR TITLE
Implement project file enumeration

### DIFF
--- a/src/DeveloperGeniue.Core/ProjectManager.cs
+++ b/src/DeveloperGeniue.Core/ProjectManager.cs
@@ -18,9 +18,31 @@ public class ProjectManager : IProjectManager
         return project;
     }
 
+    public IEnumerable<string> EnumerateProjectFiles(string root)
+    {
+        foreach (var file in Directory.EnumerateFiles(root, "*.csproj", SearchOption.TopDirectoryOnly))
+        {
+            yield return file;
+        }
+
+        foreach (var dir in Directory.EnumerateDirectories(root))
+        {
+            var name = Path.GetFileName(dir);
+            if (string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, "obj", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, ".git", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var file in EnumerateProjectFiles(dir))
+                yield return file;
+        }
+    }
+
     public async Task<IEnumerable<CodeFile>> GetProjectFilesAsync(string projectPath)
     {
-        var allowedExtensions = new[] { ".cs", ".csproj", ".sln", ".json", ".xml", ".resx" };
+        var files = EnumerateProjectFiles(projectPath)
             .Select(async f => new CodeFile
             {
                 Path = f,
@@ -74,5 +96,4 @@ public class ProjectManager : IProjectManager
         };
     }
 
-  }
 }


### PR DESCRIPTION
## Summary
- add a recursive project file enumerator in `ProjectManager`
- use enumerator when gathering project files

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c15ae239c833284be565765685276