### PR TITLE
Add database config and hybrid UI scaffolding

### DIFF
--- a/src/DeveloperGeniue.AI/DeveloperGeniue.AI.csproj
+++ b/src/DeveloperGeniue.AI/DeveloperGeniue.AI.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="../DeveloperGeniue.Core/DeveloperGeniue.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DeveloperGeniue.CLI/HybridHost.cs
+++ b/src/DeveloperGeniue.CLI/HybridHost.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
+using DeveloperGeniue.Core;
 using System.Runtime.Versioning;
 #if WINDOWS
 using System.Threading;
@@ -15,6 +16,7 @@ public static class HybridHost
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddRazorPages();
+        builder.Services.AddSingleton<IConfigurationService, DatabaseConfigurationService>();
         var app = builder.Build();
         app.MapRazorPages();
         app.MapGet("/", () => "DeveloperGeniue running");

--- a/src/DeveloperGeniue.CLI/Pages/Settings.cshtml
+++ b/src/DeveloperGeniue.CLI/Pages/Settings.cshtml
@@ -1,0 +1,8 @@
+@page
+@model SettingsModel
+<h2>Settings</h2>
+<form method="post">
+    <label for="language">Language:</label>
+    <input id="language" name="language" value="@Model.Language" />
+    <button type="submit">Save</button>
+</form>

--- a/src/DeveloperGeniue.CLI/Pages/Settings.cshtml.cs
+++ b/src/DeveloperGeniue.CLI/Pages/Settings.cshtml.cs
@@ -1,0 +1,29 @@
+using DeveloperGeniue.Core;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DeveloperGeniue.CLI;
+
+public class SettingsModel : PageModel
+{
+    private readonly IConfigurationService _config;
+    public string Language { get; set; } = "en-US";
+
+    public SettingsModel(IConfigurationService config)
+    {
+        _config = config;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Language = await _config.GetSettingAsync<string>("language") ?? "en-US";
+    }
+
+    public async Task OnPostAsync()
+    {
+        if (Request.Form.TryGetValue("language", out var lang))
+        {
+            await _config.SetSettingAsync("language", lang.ToString());
+            Language = lang;
+        }
+    }
+}

--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -1,4 +1,5 @@
 using DeveloperGeniue.Core;
+using System.Linq;
 
 namespace DeveloperGeniue.CLI;
 
@@ -6,8 +7,12 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
-        var config = new ConfigurationService();
+        IConfigurationService config = args.Contains("--db") || Environment.GetEnvironmentVariable("USE_DB_CONFIG") == "1"
+            ? new DatabaseConfigurationService()
+            : new ConfigurationService();
         var lang = new LanguageService(config);
+        await lang.GetUserLanguageAsync();
+        Console.WriteLine($"Using language: {lang.CurrentLanguage}");
 
         if (args.Length >= 2 && (args[0] == "--lang" || args[0] == "lang"))
         {

--- a/src/DeveloperGeniue.Core/AICodeOperations.cs
+++ b/src/DeveloperGeniue.Core/AICodeOperations.cs
@@ -1,0 +1,36 @@
+using DeveloperGeniue.Core.AI;
+
+namespace DeveloperGeniue.Core;
+
+/// <summary>
+/// Wraps build and test operations and sends the results to AI for analysis.
+/// </summary>
+public class AICodeOperations
+{
+    private readonly BuildManager _buildManager;
+    private readonly TestManager _testManager;
+    private readonly AIOrchestrator _orchestrator;
+
+    public AICodeOperations(BuildManager buildManager, TestManager testManager, AIOrchestrator orchestrator)
+    {
+        _buildManager = buildManager;
+        _testManager = testManager;
+        _orchestrator = orchestrator;
+    }
+
+    public async Task<BuildResult> BuildAndAnalyzeAsync(string projectPath)
+    {
+        var result = await _buildManager.BuildProjectAsync(projectPath);
+        var prompt = $"Build output for {projectPath}:\n{result.Output}\nErrors:{result.Errors}";
+        await _orchestrator.ExecuteAsync(new AIRequest(prompt, "OpenAI"));
+        return result;
+    }
+
+    public async Task<TestResult> TestAndAnalyzeAsync(string projectPath)
+    {
+        var result = await _testManager.RunTestsAsync(projectPath);
+        var prompt = $"Test results for {projectPath}: Passed {result.PassedTests}, Failed {result.FailedTests}.";
+        await _orchestrator.ExecuteAsync(new AIRequest(prompt, "Claude"));
+        return result;
+    }
+}

--- a/src/DeveloperGeniue.Core/DatabaseConfigurationService.cs
+++ b/src/DeveloperGeniue.Core/DatabaseConfigurationService.cs
@@ -1,0 +1,73 @@
+using Microsoft.Data.Sqlite;
+using System.Text.Json;
+
+namespace DeveloperGeniue.Core;
+
+/// <summary>
+/// Stores configuration settings in a SQLite database.
+/// </summary>
+public class DatabaseConfigurationService : IConfigurationService
+{
+    private readonly string _connectionString;
+
+    public DatabaseConfigurationService(string? databasePath = null)
+    {
+        var path = databasePath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "geniue_config.db");
+        _connectionString = $"Data Source={path}";
+        EnsureDatabase();
+    }
+
+    private void EnsureDatabase()
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS Settings(Key TEXT PRIMARY KEY, Value TEXT NOT NULL);";
+        cmd.ExecuteNonQuery();
+    }
+
+    public event EventHandler? SettingsChanged;
+
+    public async Task<T?> GetSettingAsync<T>(string key)
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT Value FROM Settings WHERE Key = @key";
+        cmd.Parameters.AddWithValue("@key", key);
+        var result = await cmd.ExecuteScalarAsync();
+        if (result is string s)
+            return JsonSerializer.Deserialize<T>(s);
+        return default;
+    }
+
+    public async Task<IDictionary<string, JsonElement>> GetAllSettingsAsync()
+    {
+        var dict = new Dictionary<string, JsonElement>();
+        using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT Key, Value FROM Settings";
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var key = reader.GetString(0);
+            var value = JsonSerializer.Deserialize<JsonElement>(reader.GetString(1));
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    public async Task SetSettingAsync<T>(string key, T value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "INSERT INTO Settings(Key, Value) VALUES(@key,@val) ON CONFLICT(Key) DO UPDATE SET Value = excluded.Value";
+        cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@val", json);
+        await cmd.ExecuteNonQueryAsync();
+        SettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
+++ b/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/DeveloperGeniue.Core/LanguageService.cs
+++ b/src/DeveloperGeniue.Core/LanguageService.cs
@@ -6,6 +6,7 @@ public interface ILanguageService
 {
     Task<string> GetStringAsync(string key, params object[] args);
     Task SetLanguageAsync(string languageCode);
+    Task<string> GetUserLanguageAsync();
     string CurrentLanguage { get; }
 }
 
@@ -45,6 +46,13 @@ public class LanguageService : ILanguageService
             return key;
         }
         return Format(text, args);
+    }
+
+    public async Task<string> GetUserLanguageAsync()
+    {
+        var lang = await _config.GetSettingAsync<string>("language") ?? "en-US";
+        CurrentLanguage = lang;
+        return lang;
     }
 
     private static string Format(string text, object[] args) => args.Length > 0 ? string.Format(text, args) : text;


### PR DESCRIPTION
## Summary
- add `DatabaseConfigurationService` using SQLite
- scaffold web settings page and inject database config in hybrid host
- track user language via `LanguageService.GetUserLanguageAsync`
- add AI-enhanced build/test operations
- wire CLI to choose database config with `--db`

## Testing
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj --verbosity minimal` *(fails: Assert.Contains not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c27bc5b5083329d6f277d0c3624cc