### PR TITLE
Add analytics and voice-driven features

### DIFF
--- a/Resources/az-AZ.json
+++ b/Resources/az-AZ.json
@@ -5,6 +5,8 @@
   "CLI.Command.Build": "  build <yol>  - göstərilən layihəni qur",
   "CLI.Command.Test": "  test <yol>   - layihə üçün testləri işə sal",
   "CLI.Command.UI": "  ui            - hibrid UI-ni işə sal",
+  "CLI.Command.Train": "  train [yol]  - AI modelini məşq etdir",
+  "CLI.Command.Voice": "  voice         - səsli əmr ver",
   "CLI.UnknownCommand": "Naməlum əmr. İstifadə üçün --help yazın.",
   "CLI.MissingProjectPath": "Layihə yolu göstərilməyib.",
   "CLI.MissingDirectory": "Qovluq tapılmadı: {0}",

--- a/Resources/en-US.json
+++ b/Resources/en-US.json
@@ -5,6 +5,8 @@
   "CLI.Command.Build": "  build <path>  - build specified project or solution",
   "CLI.Command.Test": "  test <path>   - run tests for specified project",
   "CLI.Command.UI": "  ui            - launch hybrid UI",
+  "CLI.Command.Train": "  train [path]  - train custom AI model",
+  "CLI.Command.Voice": "  voice         - speak a CLI command",
   "CLI.UnknownCommand": "Unknown command. Use --help for usage.",
   "CLI.MissingProjectPath": "Missing project path.",
   "CLI.MissingDirectory": "Directory not found: {0}",

--- a/src/DeveloperGeniue.AI/ModelTrainer.cs
+++ b/src/DeveloperGeniue.AI/ModelTrainer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 namespace DeveloperGeniue.AI;
 
 /// <summary>
@@ -14,5 +16,15 @@ public class ModelTrainer
     {
         // Placeholder for actual training logic.
         Console.WriteLine($"Training model with data at {dataPath}...");
+    }
+
+    /// <summary>
+    /// Prompts the user for a training data path via voice input and trains the model.
+    /// </summary>
+    public async Task TrainModelWithVoiceAsync(Speech.ISpeechInterface speech, CancellationToken cancellationToken = default)
+    {
+        Console.WriteLine("Please specify the training data path:");
+        var path = await speech.ListenForCommandAsync(cancellationToken);
+        TrainModel(path);
     }
 }

--- a/src/DeveloperGeniue.AI/PairProgramming/PairProgrammingHub.cs
+++ b/src/DeveloperGeniue.AI/PairProgramming/PairProgrammingHub.cs
@@ -15,4 +15,36 @@ public class PairProgrammingHub : Hub
     {
         await Clients.Others.SendAsync("ReceiveCodeUpdate", code);
     }
+
+    /// <summary>
+    /// Adds the caller to a collaboration session.
+    /// </summary>
+    public async Task JoinSession(string sessionId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, sessionId);
+    }
+
+    /// <summary>
+    /// Removes the caller from a collaboration session.
+    /// </summary>
+    public async Task LeaveSession(string sessionId)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, sessionId);
+    }
+
+    /// <summary>
+    /// Shares the current cursor position with collaborators.
+    /// </summary>
+    public async Task SendCursorPosition(string sessionId, int line, int column)
+    {
+        await Clients.OthersInGroup(sessionId).SendAsync("ReceiveCursorPosition", line, column);
+    }
+
+    /// <summary>
+    /// Sends a chat message to collaborators.
+    /// </summary>
+    public async Task SendChatMessage(string sessionId, string message)
+    {
+        await Clients.OthersInGroup(sessionId).SendAsync("ReceiveChatMessage", message);
+    }
 }

--- a/src/DeveloperGeniue.AI/PredictiveAnalyticsReport.cs
+++ b/src/DeveloperGeniue.AI/PredictiveAnalyticsReport.cs
@@ -1,0 +1,11 @@
+namespace DeveloperGeniue.AI;
+
+/// <summary>
+/// Represents analytics metrics and insights for a project.
+/// </summary>
+public record PredictiveAnalyticsReport(
+    int TotalFiles,
+    double AverageLinesPerFile,
+    bool BuildSucceeded,
+    double TestPassRate,
+    string Summary);

--- a/src/DeveloperGeniue.CLI/DeveloperGeniue.CLI.csproj
+++ b/src/DeveloperGeniue.CLI/DeveloperGeniue.CLI.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DeveloperGeniue.Core\DeveloperGeniue.Core.csproj" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\DeveloperGeniue.AI\DeveloperGeniue.AI.csproj" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -10,7 +11,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
 </Project>

--- a/src/DeveloperGeniue.CLI/HybridHost.cs
+++ b/src/DeveloperGeniue.CLI/HybridHost.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using DeveloperGeniue.Core;
+using DeveloperGeniue.AI.Speech;
+using Microsoft.Extensions.Hosting;
 using System.Runtime.Versioning;
 #if WINDOWS
 using System.Threading;
@@ -21,6 +23,19 @@ public static class HybridHost
         app.MapRazorPages();
         app.MapGet("/", () => "DeveloperGeniue running");
         await app.StartAsync(cancellationToken);
+
+        ISpeechInterface speech = new SpeechInterface();
+        _ = Task.Run(async () =>
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var command = await speech.ListenForCommandAsync(cancellationToken);
+                if (command.Equals("exit", StringComparison.OrdinalIgnoreCase))
+                {
+                    await app.StopAsync();
+                }
+            }
+        }, cancellationToken);
 
 #if WINDOWS
         var thread = new Thread(() => Application.Run(new Form { Text = "DeveloperGeniue" }));

--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -1,4 +1,6 @@
 using DeveloperGeniue.Core;
+using DeveloperGeniue.AI;
+using DeveloperGeniue.AI.Speech;
 using System.Linq;
 
 namespace DeveloperGeniue.CLI;
@@ -30,6 +32,8 @@ public class Program
             Console.WriteLine(await lang.GetStringAsync("CLI.Command.Build"));
             Console.WriteLine(await lang.GetStringAsync("CLI.Command.Test"));
             Console.WriteLine(await lang.GetStringAsync("CLI.Command.UI"));
+            Console.WriteLine(await lang.GetStringAsync("CLI.Command.Train"));
+            Console.WriteLine(await lang.GetStringAsync("CLI.Command.Voice"));
 
             return;
         }
@@ -90,6 +94,32 @@ public class Program
                 Console.WriteLine(result.Errors);
             }
 
+            return;
+        }
+
+        if (args[0].Equals("train", StringComparison.OrdinalIgnoreCase))
+        {
+            var trainer = new ModelTrainer();
+            if (args.Length >= 2)
+            {
+                trainer.TrainModel(args[1]);
+            }
+            else
+            {
+                ISpeechInterface speech = new SpeechInterface();
+                await trainer.TrainModelWithVoiceAsync(speech);
+            }
+            return;
+        }
+
+        if (args[0].Equals("voice", StringComparison.OrdinalIgnoreCase))
+        {
+            ISpeechInterface speech = new SpeechInterface();
+            Console.WriteLine("Speak command:");
+            var spoken = await speech.ListenForCommandAsync();
+            var voiceArgs = spoken.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (voiceArgs.Length > 0)
+                await Main(voiceArgs);
             return;
         }
 

--- a/tests/DeveloperGeniue.Tests/ModelTrainerTests.cs
+++ b/tests/DeveloperGeniue.Tests/ModelTrainerTests.cs
@@ -1,0 +1,29 @@
+using DeveloperGeniue.AI;
+using DeveloperGeniue.AI.Speech;
+using Xunit;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DeveloperGeniue.Tests;
+
+public class ModelTrainerTests
+{
+    private class StubSpeech : ISpeechInterface
+    {
+        public Task<string> ListenForCommandAsync(System.Threading.CancellationToken cancellationToken = default)
+            => Task.FromResult("data.csv");
+    }
+
+    [Fact]
+    public async Task TrainModelWithVoiceUsesSpeechInput()
+    {
+        var speech = new StubSpeech();
+        var trainer = new ModelTrainer();
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        await trainer.TrainModelWithVoiceAsync(speech);
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+        Assert.Contains("data.csv", sw.ToString());
+    }
+}

--- a/tests/DeveloperGeniue.Tests/PredictiveAnalyticsServiceTests.cs
+++ b/tests/DeveloperGeniue.Tests/PredictiveAnalyticsServiceTests.cs
@@ -1,0 +1,30 @@
+using DeveloperGeniue.AI;
+using DeveloperGeniue.Core;
+using Xunit;
+
+namespace DeveloperGeniue.Tests;
+
+public class PredictiveAnalyticsServiceTests
+{
+    [Fact]
+    public void AnalyzeReturnsDetailedReport()
+    {
+        var project = new Project
+        {
+            Files = new()
+            {
+                new CodeFile { Content = "line1\nline2" }
+            }
+        };
+        var build = new BuildResult { Success = true };
+        var tests = new TestResult { PassedTests = 2, FailedTests = 1, TotalTests = 3 };
+
+        var service = new PredictiveAnalyticsService();
+        var report = service.Analyze(project, build, tests);
+
+        Assert.Equal(1, report.TotalFiles);
+        Assert.True(report.BuildSucceeded);
+        Assert.InRange(report.TestPassRate, 0.66, 0.67);
+        Assert.Contains("build succeeded", report.Summary);
+    }
+}


### PR DESCRIPTION
## Summary
- expand PredictiveAnalyticsService to compute metrics and summary
- add record class PredictiveAnalyticsReport
- implement voice-based training in ModelTrainer
- enhance real-time collaboration hub with session management
- integrate speech commands into CLI and HybridHost
- localize new CLI commands
- add unit tests for analytics and voice training

## Testing
- `dotnet build DeveloperGeniue.sln -v q`
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj --no-build -v minimal` *(fails: BuildManager tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684c2b26de0483328cf739f2d6705359