### PR TITLE
Add language resources and cloud AI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ dotnet run --project src/DeveloperGeniue.CLI -- provenance <commit-hash>
 dotnet run --project src/DeveloperGeniue.CLI -- evolution
 ```
 
+### Analyze quantum readiness
+
+Generate a simple compatibility report:
+
+```bash
+dotnet run --project src/DeveloperGeniue.CLI -- quantum path/to/project.csproj
+```
+
+### Configure cloud AI provider
+
+Set configuration values `CloudAIProvider`, `AzureAIEndpoint`/`AzureAIKey` or `AWSAIEndpoint`/`AWSAIKey` to use cloud intelligence services.
+
+### Supported languages
+
+Resource files now include English (`en-US`), Azerbaijani (`az-AZ`), Turkish (`tr-TR`) and Russian (`ru-RU`). Switch languages via:
+
+```bash
+dotnet run --project src/DeveloperGeniue.CLI --lang tr-TR
+```
+
 ## Repository Structure
 
 ```

--- a/Resources/ru-RU.json
+++ b/Resources/ru-RU.json
@@ -1,0 +1,25 @@
+{
+  "CLI.Header": "DeveloperGeniue CLI",
+  "CLI.Commands": "Команды:",
+  "CLI.Command.Scan": "  scan [путь]   - перечислить проекты в каталоге",
+  "CLI.Command.Build": "  build <путь>  - собрать указанный проект или решение",
+  "CLI.Command.Test": "  test <путь>   - запустить тесты для указанного проекта",
+  "CLI.Command.UI": "  ui            - запустить гибридный интерфейс",
+  "CLI.Command.Train": "  train [путь]  - обучить пользовательскую AI модель",
+  "CLI.Command.Voice": "  voice         - произнести команду CLI",
+  "CLI.Command.Viz": "  viz <путь>    - открыть 3D визуализацию",
+  "CLI.Command.AR": "  ar <путь>     - начать AR код-ревью",
+  "CLI.Command.Provenance": "  provenance <хеш> - зарегистрировать коммит в блокчейне",
+  "CLI.Command.Evolution": "  evolution     - показать аналитику эволюции кода",
+  "CLI.UnknownCommand": "Неизвестная команда. Используйте --help для справки.",
+  "CLI.MissingProjectPath": "Не указан путь к проекту.",
+  "CLI.MissingDirectory": "Каталог не найден: {0}",
+  "CLI.LanguageSet": "Язык установлен на {0}",
+  "CLI.TestsPassed": "Тестов пройдено: {0}",
+  "CLI.TestsFailed": "Тестов провалено: {0}",
+  "CLI.TestsSkipped": "Пропущено тестов: {0}",
+  "CLI.TestsTotal": "Всего тестов: {0}",
+  "CLI.TestsDuration": "Длительность: {0}",
+  "CLI.TestErrors": "Ошибки тестов:"
+}
+

--- a/Resources/tr-TR.json
+++ b/Resources/tr-TR.json
@@ -1,0 +1,25 @@
+{
+  "CLI.Header": "DeveloperGeniue CLI",
+  "CLI.Commands": "Komutlar:",
+  "CLI.Command.Scan": "  scan [yol]   - dizindeki projeleri listele",
+  "CLI.Command.Build": "  build <yol>  - belirtilen projeyi veya çözümü derle",
+  "CLI.Command.Test": "  test <yol>   - belirtilen proje için testleri çalıştır",
+  "CLI.Command.UI": "  ui            - hibrit UI'yi başlat",
+  "CLI.Command.Train": "  train [yol]  - özel AI modelini eğit",
+  "CLI.Command.Voice": "  voice         - bir CLI komutunu konuş",
+  "CLI.Command.Viz": "  viz <yol>    - 3D görselleştirmeyi aç",
+  "CLI.Command.AR": "  ar <yol>     - AR kod incelemesini başlat",
+  "CLI.Command.Provenance": "  provenance <hash> - blockchain'de commiti kaydet",
+  "CLI.Command.Evolution": "  evolution     - kod evrim analizini göster",
+  "CLI.UnknownCommand": "Bilinmeyen komut. Kullanım için --help yazın.",
+  "CLI.MissingProjectPath": "Proje yolu eksik.",
+  "CLI.MissingDirectory": "Dizin bulunamadı: {0}",
+  "CLI.LanguageSet": "Dil {0} olarak ayarlandı",
+  "CLI.TestsPassed": "Geçen Testler: {0}",
+  "CLI.TestsFailed": "Başarısız Testler: {0}",
+  "CLI.TestsSkipped": "Atlanan Testler: {0}",
+  "CLI.TestsTotal": "Toplam Test: {0}",
+  "CLI.TestsDuration": "Süre: {0}",
+  "CLI.TestErrors": "Test Hataları:"
+}
+

--- a/src/DeveloperGeniue.Collaboration/MergeConflictResolver.cs
+++ b/src/DeveloperGeniue.Collaboration/MergeConflictResolver.cs
@@ -1,0 +1,19 @@
+namespace DeveloperGeniue.Collaboration;
+
+public interface IMergeConflictResolver
+{
+    Task<string> ResolveAsync(string baseCode, string incomingCode);
+}
+
+/// <summary>
+/// Simple merge conflict resolver that concatenates conflicting code sections.
+/// </summary>
+public class SimpleMergeConflictResolver : IMergeConflictResolver
+{
+    public Task<string> ResolveAsync(string baseCode, string incomingCode)
+    {
+        if (string.Equals(baseCode, incomingCode, StringComparison.Ordinal))
+            return Task.FromResult(baseCode);
+        return Task.FromResult(baseCode + "\n" + incomingCode);
+    }
+}

--- a/src/DeveloperGeniue.Core/CloudIntelligenceService.cs
+++ b/src/DeveloperGeniue.Core/CloudIntelligenceService.cs
@@ -15,8 +15,26 @@ public class CloudIntelligenceService : ICloudIntelligenceService
 
     public async Task<string> ExecuteAsync(string prompt, CancellationToken cancellationToken = default)
     {
-        // Example integration point for cloud AI providers (Azure or AWS)
-        var endpoint = await _config.GetSettingAsync<string>("CloudAIEndpoint") ?? string.Empty;
+        // Resolve provider and endpoint from configuration
+        var provider = (await _config.GetSettingAsync<string>("CloudAIProvider"))?.ToLowerInvariant();
+        string? endpoint = null;
+        string? apiKey = null;
+
+        if (provider == "azure")
+        {
+            endpoint = await _config.GetSettingAsync<string>("AzureAIEndpoint");
+            apiKey = await _config.GetSettingAsync<string>("AzureAIKey");
+        }
+        else if (provider == "aws")
+        {
+            endpoint = await _config.GetSettingAsync<string>("AWSAIEndpoint");
+            apiKey = await _config.GetSettingAsync<string>("AWSAIKey");
+        }
+        else
+        {
+            endpoint = await _config.GetSettingAsync<string>("CloudAIEndpoint");
+        }
+
         if (string.IsNullOrEmpty(endpoint))
             return string.Empty;
 
@@ -24,6 +42,9 @@ public class CloudIntelligenceService : ICloudIntelligenceService
         {
             Content = new StringContent(prompt, Encoding.UTF8, "text/plain")
         };
+        if (!string.IsNullOrEmpty(apiKey))
+            req.Headers.Add("Authorization", $"Bearer {apiKey}");
+
         var resp = await _http.SendAsync(req, cancellationToken);
         resp.EnsureSuccessStatusCode();
         return await resp.Content.ReadAsStringAsync(cancellationToken);

--- a/tests/DeveloperGeniue.Tests/LanguageServiceLocalizationTests.cs
+++ b/tests/DeveloperGeniue.Tests/LanguageServiceLocalizationTests.cs
@@ -1,0 +1,20 @@
+using DeveloperGeniue.Core;
+
+namespace DeveloperGeniue.Tests;
+
+public class LanguageServiceLocalizationTests
+{
+    [Theory]
+    [InlineData("tr-TR", "Komutlar:")]
+    [InlineData("ru-RU", "Команды:")]
+    public async Task LoadsLocalizedStrings(string language, string expected)
+    {
+        var configFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var config = new ConfigurationService(configFile);
+        var service = new LanguageService(config, Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "Resources"));
+        await service.SetLanguageAsync(language);
+        var result = await service.GetStringAsync("CLI.Commands");
+        Assert.Equal(expected, result);
+        File.Delete(configFile);
+    }
+}


### PR DESCRIPTION
## Summary
- support Turkish and Russian language resources
- allow Azure or AWS cloud AI providers via configuration
- provide simple merge conflict resolver stub
- add localization unit tests
- document cloud configuration and languages

## Testing
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj --no-build --verbosity minimal` *(fails: ModelTrainer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8260e5b883328b96269edf5d7cf8