### PR TITLE
Add advanced AI features and voice improvements

### DIFF
--- a/src/DeveloperGeniue.AI/ModelTrainer.cs
+++ b/src/DeveloperGeniue.AI/ModelTrainer.cs
@@ -19,12 +19,22 @@ public class ModelTrainer
     }
 
     /// <summary>
+    /// Asynchronously trains the model using the provided dataset path.
+    /// </summary>
+    public async Task<ModelTrainingReport> TrainModelAsync(string dataPath, CancellationToken cancellationToken = default)
+    {
+        TrainModel(dataPath);
+        await Task.Delay(500, cancellationToken); // simulate work
+        return new ModelTrainingReport(true, $"Model trained with {dataPath}");
+    }
+
+    /// <summary>
     /// Prompts the user for a training data path via voice input and trains the model.
     /// </summary>
     public async Task TrainModelWithVoiceAsync(Speech.ISpeechInterface speech, CancellationToken cancellationToken = default)
     {
-        Console.WriteLine("Please specify the training data path:");
+        await speech.SpeakAsync("Please specify the training data path:", cancellationToken);
         var path = await speech.ListenForCommandAsync(cancellationToken);
-        TrainModel(path);
+        await TrainModelAsync(path, cancellationToken);
     }
 }

--- a/src/DeveloperGeniue.AI/ModelTrainingReport.cs
+++ b/src/DeveloperGeniue.AI/ModelTrainingReport.cs
@@ -1,0 +1,6 @@
+namespace DeveloperGeniue.AI;
+
+/// <summary>
+/// Represents the result of a model training session.
+/// </summary>
+public record ModelTrainingReport(bool Success, string Summary);

--- a/src/DeveloperGeniue.AI/PairProgramming/PairProgrammingHub.cs
+++ b/src/DeveloperGeniue.AI/PairProgramming/PairProgrammingHub.cs
@@ -47,4 +47,12 @@ public class PairProgrammingHub : Hub
     {
         await Clients.OthersInGroup(sessionId).SendAsync("ReceiveChatMessage", message);
     }
+
+    /// <summary>
+    /// Sends a voice command transcription to collaborators.
+    /// </summary>
+    public async Task SendVoiceCommand(string sessionId, string command)
+    {
+        await Clients.OthersInGroup(sessionId).SendAsync("ReceiveVoiceCommand", command);
+    }
 }

--- a/src/DeveloperGeniue.AI/PredictiveAnalyticsReport.cs
+++ b/src/DeveloperGeniue.AI/PredictiveAnalyticsReport.cs
@@ -8,4 +8,5 @@ public record PredictiveAnalyticsReport(
     double AverageLinesPerFile,
     bool BuildSucceeded,
     double TestPassRate,
-    string Summary);
+    string Summary,
+    string Trend);

--- a/src/DeveloperGeniue.AI/PredictiveAnalyticsService.cs
+++ b/src/DeveloperGeniue.AI/PredictiveAnalyticsService.cs
@@ -1,5 +1,6 @@
 using DeveloperGeniue.Core;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace DeveloperGeniue.AI;
 
@@ -11,7 +12,7 @@ public class PredictiveAnalyticsService
     /// <summary>
     /// Gathers statistics from the provided project and optional results to return a simple prediction summary.
     /// </summary>
-    public PredictiveAnalyticsReport Analyze(Project project, BuildResult? build = null, TestResult? tests = null)
+    public PredictiveAnalyticsReport Analyze(Project project, BuildResult? build = null, TestResult? tests = null, IEnumerable<int>? historicalFileCounts = null)
     {
         int totalFiles = project.Files.Count;
         double avgLines = totalFiles == 0
@@ -33,6 +34,17 @@ public class PredictiveAnalyticsService
             summary += $", tests pass rate {passRate:P0}";
         }
 
-        return new PredictiveAnalyticsReport(totalFiles, avgLines, buildSucceeded, passRate, summary);
+        string trend = "stable";
+        if (historicalFileCounts != null && historicalFileCounts.Any())
+        {
+            double avgHistory = historicalFileCounts.Average();
+            trend = totalFiles > avgHistory
+                ? "growing"
+                : totalFiles < avgHistory
+                    ? "shrinking"
+                    : "stable";
+        }
+
+        return new PredictiveAnalyticsReport(totalFiles, avgLines, buildSucceeded, passRate, summary, trend);
     }
 }

--- a/src/DeveloperGeniue.AI/Speech/ISpeechInterface.cs
+++ b/src/DeveloperGeniue.AI/Speech/ISpeechInterface.cs
@@ -11,4 +11,9 @@ public interface ISpeechInterface
     /// Listens for a single command and returns the recognized text.
     /// </summary>
     Task<string> ListenForCommandAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Speaks the provided text to the user.
+    /// </summary>
+    Task SpeakAsync(string text, CancellationToken cancellationToken = default);
 }

--- a/src/DeveloperGeniue.AI/Speech/SpeechInterface.cs
+++ b/src/DeveloperGeniue.AI/Speech/SpeechInterface.cs
@@ -17,4 +17,10 @@ public class SpeechInterface : ISpeechInterface
         string? input = Console.ReadLine();
         return Task.FromResult(input ?? string.Empty);
     }
+
+    public Task SpeakAsync(string text, CancellationToken cancellationToken = default)
+    {
+        Console.WriteLine(text);
+        return Task.CompletedTask;
+    }
 }

--- a/src/DeveloperGeniue.Core/AI/AIOrchestrator.cs
+++ b/src/DeveloperGeniue.Core/AI/AIOrchestrator.cs
@@ -6,6 +6,13 @@ public class AIOrchestrator
 {
     private readonly ConcurrentDictionary<string, IAIClient> _providers = new();
 
+    public AIOrchestrator()
+    {
+        // Register built-in providers for convenience
+        RegisterProvider("OpenAI", new OpenAIClient());
+        RegisterProvider("Claude", new ClaudeAIClient());
+    }
+
     public void RegisterProvider(string name, IAIClient client)
     {
         _providers[name] = client;
@@ -20,4 +27,13 @@ public class AIOrchestrator
 
         return await provider.GetCompletionAsync(request, cancellationToken);
     }
+
+    public Task<AIResponse> AnalyzeCodeAsync(string code, CancellationToken cancellationToken = default)
+        => ExecuteAsync(new AIRequest($"Analyze the following C# code for potential issues:\n{code}", "OpenAI"), cancellationToken);
+
+    public Task<AIResponse> RefactorCodeAsync(string code, CancellationToken cancellationToken = default)
+        => ExecuteAsync(new AIRequest($"Refactor the following C# code for readability and performance:\n{code}", "Claude"), cancellationToken);
+
+    public Task<AIResponse> GenerateDocumentationAsync(string code, CancellationToken cancellationToken = default)
+        => ExecuteAsync(new AIRequest($"Generate documentation for this C# code:\n{code}", "OpenAI"), cancellationToken);
 }

--- a/tests/DeveloperGeniue.Tests/AIOrchestratorExtendedTests.cs
+++ b/tests/DeveloperGeniue.Tests/AIOrchestratorExtendedTests.cs
@@ -1,0 +1,28 @@
+using DeveloperGeniue.Core.AI;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DeveloperGeniue.Tests;
+
+public class AIOrchestratorExtendedTests
+{
+    private class StubClient : IAIClient
+    {
+        public AIRequest? ReceivedRequest { get; private set; }
+        public Task<AIResponse> GetCompletionAsync(AIRequest request, CancellationToken cancellationToken = default)
+        {
+            ReceivedRequest = request;
+            return Task.FromResult(new AIResponse("ok"));
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeCodeAsyncUsesOpenAI()
+    {
+        var client = new StubClient();
+        var orchestrator = new AIOrchestrator();
+        orchestrator.RegisterProvider("OpenAI", client);
+        await orchestrator.AnalyzeCodeAsync("class C{}", CancellationToken.None);
+        Assert.Equal("OpenAI", client.ReceivedRequest?.Provider);
+    }
+}

--- a/tests/DeveloperGeniue.Tests/ModelTrainerTests.cs
+++ b/tests/DeveloperGeniue.Tests/ModelTrainerTests.cs
@@ -13,6 +13,9 @@ public class ModelTrainerTests
     {
         public Task<string> ListenForCommandAsync(System.Threading.CancellationToken cancellationToken = default)
             => Task.FromResult("data.csv");
+
+        public Task SpeakAsync(string text, System.Threading.CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 
     [Fact]

--- a/tests/DeveloperGeniue.Tests/PredictiveAnalyticsServiceTests.cs
+++ b/tests/DeveloperGeniue.Tests/PredictiveAnalyticsServiceTests.cs
@@ -26,5 +26,15 @@ public class PredictiveAnalyticsServiceTests
         Assert.True(report.BuildSucceeded);
         Assert.InRange(report.TestPassRate, 0.66, 0.67);
         Assert.Contains("build succeeded", report.Summary);
+        Assert.Equal("stable", report.Trend);
+    }
+
+    [Fact]
+    public void AnalyzeWithHistoryDetectsTrend()
+    {
+        var project = new Project { Files = new() { new CodeFile() } };
+        var service = new PredictiveAnalyticsService();
+        var report = service.Analyze(project, null, null, new[] { 5, 6, 7 });
+        Assert.Equal("shrinking", report.Trend);
     }
 }

--- a/tests/DeveloperGeniue.Tests/SpeechInterfaceTests.cs
+++ b/tests/DeveloperGeniue.Tests/SpeechInterfaceTests.cs
@@ -16,4 +16,15 @@ public class SpeechInterfaceTests
         var command = await speech.ListenForCommandAsync();
         Assert.Equal("hello", command);
     }
+
+    [Fact]
+    public async Task SpeakAsyncWritesOutput()
+    {
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        var speech = new SpeechInterface();
+        await speech.SpeakAsync("hi");
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+        Assert.Contains("hi", sw.ToString());
+    }
 }


### PR DESCRIPTION
## Summary
- extend `AIOrchestrator` with built-in providers and new analysis, refactor and documentation helpers
- upgrade `ModelTrainer` with async training and voice prompts
- enhance `PredictiveAnalyticsService` with simple trend analysis
- update speech interface with `SpeakAsync` and improve pair programming hub
- adjust tests for new features and add coverage for orchestrator and analytics

## Testing
- `dotnet build DeveloperGeniue.sln -c Release` *(fails: Certificate retrieval blocked)*
- `dotnet test DeveloperGeniue.sln --no-build` *(fails: no output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684c89e31d9083328ca3682fc0ab2b17