### PR TITLE
Add database config persistence test

### DIFF
--- a/tests/DeveloperGeniue.Tests/DatabaseConfigurationServiceTests.cs
+++ b/tests/DeveloperGeniue.Tests/DatabaseConfigurationServiceTests.cs
@@ -1,0 +1,21 @@
+using DeveloperGeniue.Core;
+
+namespace DeveloperGeniue.Tests;
+
+public class DatabaseConfigurationServiceTests
+{
+    [Fact]
+    public async Task SetAndGetSetting_PersistsValue()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var service = new DatabaseConfigurationService(dbPath);
+
+        await service.SetSettingAsync("TestKey", "TestValue");
+
+        service = new DatabaseConfigurationService(dbPath);
+        var result = await service.GetSettingAsync<string>("TestKey");
+
+        Assert.Equal("TestValue", result);
+        File.Delete(dbPath);
+    }
+}


### PR DESCRIPTION
## Summary
- test DatabaseConfigurationService persistence using SQLite

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d07472d1c8332bbbdf5873b19b8e7