### PR TITLE
Use ConfigurationService for AI API keys

### DIFF
--- a/src/DeveloperGeniue.Core/AI/AIOrchestrator.cs
+++ b/src/DeveloperGeniue.Core/AI/AIOrchestrator.cs
@@ -6,11 +6,15 @@ public class AIOrchestrator
 {
     private readonly ConcurrentDictionary<string, IAIClient> _providers = new();
 
-    public AIOrchestrator()
+    private readonly IConfigurationService _config;
+
+    public AIOrchestrator(IConfigurationService config)
     {
+        _config = config;
+
         // Register built-in providers for convenience
-        RegisterProvider("OpenAI", new OpenAIClient());
-        RegisterProvider("Claude", new ClaudeAIClient());
+        RegisterProvider("OpenAI", new OpenAIClient(_config));
+        RegisterProvider("Claude", new ClaudeAIClient(_config));
     }
 
     public void RegisterProvider(string name, IAIClient client)

--- a/src/DeveloperGeniue.Core/AI/ClaudeAIClient.cs
+++ b/src/DeveloperGeniue.Core/AI/ClaudeAIClient.cs
@@ -7,12 +7,12 @@ namespace DeveloperGeniue.Core.AI;
 public class ClaudeAIClient : IAIClient
 {
     private readonly HttpClient _httpClient;
-    private readonly string _apiKey;
+    private readonly IConfigurationService _config;
 
-    public ClaudeAIClient(HttpClient? httpClient = null, string? apiKey = null)
+    public ClaudeAIClient(IConfigurationService config, HttpClient? httpClient = null)
     {
+        _config = config;
         _httpClient = httpClient ?? new HttpClient();
-        _apiKey = apiKey ?? Environment.GetEnvironmentVariable("CLAUDE_API_KEY") ?? string.Empty;
     }
 
     public async Task<AIResponse> GetCompletionAsync(AIRequest request, CancellationToken cancellationToken = default)
@@ -22,7 +22,10 @@ public class ClaudeAIClient : IAIClient
         {
             Content = JsonContent.Create(payload)
         };
-        msg.Headers.Add("x-api-key", _apiKey);
+
+        var apiKey = await _config.GetSettingAsync<string>("ClaudeApiKey") ?? string.Empty;
+        msg.Headers.Add("x-api-key", apiKey);
+
         var resp = await _httpClient.SendAsync(msg, cancellationToken);
         if (!resp.IsSuccessStatusCode)
         {

--- a/tests/DeveloperGeniue.Tests/AIOrchestratorExtendedTests.cs
+++ b/tests/DeveloperGeniue.Tests/AIOrchestratorExtendedTests.cs
@@ -1,3 +1,4 @@
+using DeveloperGeniue.Core;
 using DeveloperGeniue.Core.AI;
 using System.Threading.Tasks;
 using Xunit;
@@ -20,9 +21,14 @@ public class AIOrchestratorExtendedTests
     public async Task AnalyzeCodeAsyncUsesOpenAI()
     {
         var client = new StubClient();
-        var orchestrator = new AIOrchestrator();
+        var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var config = new ConfigurationService(file);
+        await config.SetSettingAsync("OpenAIApiKey", "test");
+        await config.SetSettingAsync("ClaudeApiKey", "test");
+        var orchestrator = new AIOrchestrator(config);
         orchestrator.RegisterProvider("OpenAI", client);
         await orchestrator.AnalyzeCodeAsync("class C{}", CancellationToken.None);
         Assert.Equal("OpenAI", client.ReceivedRequest?.Provider);
+        File.Delete(file);
     }
 }

--- a/tests/DeveloperGeniue.Tests/AIOrchestratorTests.cs
+++ b/tests/DeveloperGeniue.Tests/AIOrchestratorTests.cs
@@ -1,3 +1,4 @@
+using DeveloperGeniue.Core;
 using DeveloperGeniue.Core.AI;
 
 namespace DeveloperGeniue.Tests;
@@ -7,7 +8,12 @@ public class AIOrchestratorTests
     [Fact]
     public async Task ExecuteAsyncThrowsForUnknownProvider()
     {
-        var orchestrator = new AIOrchestrator();
+        var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var config = new ConfigurationService(file);
+        await config.SetSettingAsync("OpenAIApiKey", "test");
+        await config.SetSettingAsync("ClaudeApiKey", "test");
+        var orchestrator = new AIOrchestrator(config);
         await Assert.ThrowsAsync<InvalidOperationException>(() => orchestrator.ExecuteAsync(new AIRequest("hi", "none")));
+        File.Delete(file);
     }
 }

--- a/tests/DeveloperGeniue.Tests/ClaudeAIClientTests.cs
+++ b/tests/DeveloperGeniue.Tests/ClaudeAIClientTests.cs
@@ -1,0 +1,45 @@
+using DeveloperGeniue.Core;
+using DeveloperGeniue.Core.AI;
+using System.Net;
+using System.Net.Http;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DeveloperGeniue.Tests;
+
+public class ClaudeAIClientTests
+{
+    private class Handler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            var json = "{\"completion\":\"ok\"}";
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task UsesApiKeyFromConfiguration()
+    {
+        var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var config = new ConfigurationService(file);
+        await config.SetSettingAsync("ClaudeApiKey", "abc");
+        var handler = new Handler();
+        var client = new ClaudeAIClient(config, new HttpClient(handler));
+
+        var result = await client.GetCompletionAsync(new AIRequest("hi", "Claude"));
+
+        var key = handler.Request?.Headers.GetValues("x-api-key").FirstOrDefault();
+        Assert.Equal("abc", key);
+        Assert.Equal("ok", result.Content);
+        File.Delete(file);
+    }
+}

--- a/tests/DeveloperGeniue.Tests/OpenAIClientTests.cs
+++ b/tests/DeveloperGeniue.Tests/OpenAIClientTests.cs
@@ -1,0 +1,45 @@
+using DeveloperGeniue.Core;
+using DeveloperGeniue.Core.AI;
+using System.Net;
+using System.Net.Http;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DeveloperGeniue.Tests;
+
+public class OpenAIClientTests
+{
+    private class Handler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            var json = "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}";
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task UsesApiKeyFromConfiguration()
+    {
+        var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var config = new ConfigurationService(file);
+        await config.SetSettingAsync("OpenAIApiKey", "abc");
+        var handler = new Handler();
+        var client = new OpenAIClient(config, new HttpClient(handler));
+
+        var result = await client.GetCompletionAsync(new AIRequest("hi", "OpenAI"));
+
+        var auth = handler.Request?.Headers.GetValues("Authorization").FirstOrDefault();
+        Assert.Equal("Bearer abc", auth);
+        Assert.Equal("ok", result.Content);
+        File.Delete(file);
+    }
+}


### PR DESCRIPTION
## Summary
- inject `IConfigurationService` into `OpenAIClient` and `ClaudeAIClient`
- adjust `AIOrchestrator` to pass configuration to the clients
- update orchestrator unit tests for new constructor
- add tests ensuring API keys come from `ConfigurationService`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0b3c14188332a4e3eedb98bf0123