### PR TITLE
Integrate Serilog logging

### DIFF
--- a/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
+++ b/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/DeveloperGeniue.Core/LoggingConfiguration.cs
+++ b/src/DeveloperGeniue.Core/LoggingConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+
+namespace DeveloperGeniue.Core;
+
+public static class LoggingConfiguration
+{
+    public static ILoggerFactory CreateLoggerFactory(string? logfile = null)
+    {
+        var config = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .Enrich.FromLogContext()
+            .WriteTo.Console();
+        if (!string.IsNullOrWhiteSpace(logfile))
+        {
+            config = config.WriteTo.File(logfile);
+        }
+
+        Log.Logger = config.CreateLogger();
+        return new SerilogLoggerFactory(Log.Logger, dispose: true);
+    }
+}

--- a/src/DeveloperGeniue.Core/TestManager.cs
+++ b/src/DeveloperGeniue.Core/TestManager.cs
@@ -1,13 +1,26 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 
 namespace DeveloperGeniue.Core;
 
 public class TestManager : ITestManager
 {
+    private readonly ILogger<TestManager> _logger;
+
+    public TestManager() : this(Microsoft.Extensions.Logging.Abstractions.NullLogger<TestManager>.Instance)
+    {
+    }
+
+    public TestManager(ILogger<TestManager> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     public async Task<TestResult> RunTestsAsync(string projectPath)
     {
+        _logger.LogInformation("Running tests for {ProjectPath}", projectPath);
         var startTime = DateTime.UtcNow;
         var process = new Process
         {
@@ -38,6 +51,7 @@ public class TestManager : ITestManager
         catch (Exception ex)
         {
             errors.AppendLine(ex.Message);
+            _logger.LogError(ex, "Tests failed to run for {ProjectPath}", projectPath);
             return new TestResult
             {
                 Success = false,
@@ -55,6 +69,7 @@ public class TestManager : ITestManager
         result.Duration = duration;
         result.Output = outputText;
         result.Errors = errorsText;
+        _logger.LogInformation("Test run completed with exit code {ExitCode} in {Duration}", process.ExitCode, duration);
         return result;
     }
 

--- a/tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj
+++ b/tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj
@@ -20,6 +20,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DeveloperGeniue.Tests/InMemorySink.cs
+++ b/tests/DeveloperGeniue.Tests/InMemorySink.cs
@@ -1,0 +1,17 @@
+using Serilog.Core;
+using Serilog.Events;
+using System.Collections.Concurrent;
+
+namespace DeveloperGeniue.Tests;
+
+public class InMemorySink : ILogEventSink
+{
+    private readonly ConcurrentBag<LogEvent> _events = new();
+
+    public void Emit(LogEvent logEvent)
+    {
+        _events.Add(logEvent);
+    }
+
+    public IReadOnlyCollection<LogEvent> Events => _events;
+}

--- a/tests/DeveloperGeniue.Tests/LoggingTests.cs
+++ b/tests/DeveloperGeniue.Tests/LoggingTests.cs
@@ -1,0 +1,36 @@
+using DeveloperGeniue.Core;
+using Serilog;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+
+namespace DeveloperGeniue.Tests;
+
+public class LoggingTests
+{
+    [Fact]
+    public async Task BuildManagerLogsMessages()
+    {
+        var sink = new InMemorySink();
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        var factory = new SerilogLoggerFactory(logger, dispose: true);
+        var bm = new BuildManager(factory.CreateLogger<BuildManager>());
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var fake = Path.Combine(tempDir, "dotnet");
+        await File.WriteAllTextAsync(fake, "#!/bin/sh\necho building $@\n");
+        System.Diagnostics.Process.Start("chmod", $"+x {fake}").WaitForExit();
+        var oldPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+
+        await bm.BuildProjectAsync("proj.csproj");
+
+        Environment.SetEnvironmentVariable("PATH", oldPath);
+        Directory.Delete(tempDir, true);
+
+        Assert.Contains(sink.Events, e => e.Level == LogEventLevel.Information);
+    }
+}


### PR DESCRIPTION
## Summary
- add Serilog configuration helper
- inject loggers into core managers
- log build/test/project actions with structured messages
- verify logging using an in-memory Serilog sink
- reference Serilog packages in projects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0b413fd08332a45feb15d25da262