### PR TITLE
Refactor LanguageService to async initialization

### DIFF
--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -13,7 +13,7 @@ public class Program
     {
         IConfigurationService config = new DatabaseConfigurationService();
         var lang = new LanguageService(config);
-        await lang.GetUserLanguageAsync();
+        await lang.InitializeAsync();
         Console.WriteLine($"Using language: {lang.CurrentLanguage}");
 
         if (args.Length >= 2 && (args[0] == "--lang" || args[0] == "lang"))


### PR DESCRIPTION
## Summary
- avoid synchronous wait in `LanguageService` constructor
- add `InitializeAsync` and lazy-load configuration
- update CLI to call `InitializeAsync`

## Testing
- `dotnet test DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj -v minimal` *(fails: command blocked or timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684d0b42ad008332a82f13e335607b58