### PR TITLE
Add .editorconfig for C# formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+tab_width = 4
+csharp_new_line_before_open_brace = all
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace
+
+[*.{csproj,props,targets}]
+indent_style = space
+indent_size = 2
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to this project! These guidelines outline
 
 ## Coding Standards
 
-- **Language Style:** Follow generally accepted community standards. For Python code, adhere to [PEP 8](https://peps.python.org/pep-0008/). For JavaScript/TypeScript, follow the [Airbnb style guide](https://github.com/airbnb/javascript) with Prettier for formatting.
+- **Language Style:** Follow generally accepted community standards. For Python code, adhere to [PEP 8](https://peps.python.org/pep-0008/). For JavaScript/TypeScript, follow the [Airbnb style guide](https://github.com/airbnb/javascript) with Prettier for formatting. For C# code, use the .NET conventions enforced by the repository's `.editorconfig` file (four-space indentation, `LF` line endings, braces on new lines).
 - **Documentation:** Include docstrings or comments for all major functions, classes, and modules. Keep the README and other documentation up to date with your changes.
 - **Commit Messages:** Write clear, concise commit messages. Use the present tense and describe what the commit does (e.g., "Add CONTRIBUTING guidelines").
 


### PR DESCRIPTION
## Summary
- add repository-wide `.editorconfig` with C# conventions
- document formatting rules in CONTRIBUTING

## Testing
- `dotnet test DeveloperGeniue.sln --configuration Release --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0b44900483329ced03a9890e4705