### PR TITLE
Secure API settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ dotnet run --project src/DeveloperGeniue.CLI -- quantum path/to/project.csproj
 
 Set configuration values `CloudAIProvider`, `AzureAIEndpoint`/`AzureAIKey` or `AWSAIEndpoint`/`AWSAIKey` to use cloud intelligence services.
 
+### Secure API key storage
+
+API keys are encrypted when stored in configuration files or the local database. On Windows, [DPAPI](https://learn.microsoft.com/dotnet/api/system.security.cryptography.protecteddata) protects the values for the current user. On other platforms, an AES key derived from the `GENIUE_PASSPHRASE` environment variable is used. The CLI and web host read this variable to access your keys.
+
 ### Supported languages
 
 Resource files now include English (`en-US`), Azerbaijani (`az-AZ`), Turkish (`tr-TR`) and Russian (`ru-RU`). Switch languages via:

--- a/src/DeveloperGeniue.CLI/HybridHost.cs
+++ b/src/DeveloperGeniue.CLI/HybridHost.cs
@@ -20,7 +20,8 @@ public static class HybridHost
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddRazorPages();
         builder.Services.AddServerSideBlazor();
-        builder.Services.AddSingleton<IConfigurationService, DatabaseConfigurationService>();
+        var passphrase = Environment.GetEnvironmentVariable("GENIUE_PASSPHRASE");
+        builder.Services.AddSingleton<IConfigurationService>(_ => new DatabaseConfigurationService(null, passphrase));
         var app = builder.Build();
         app.MapRazorPages();
         app.MapBlazorHub();

--- a/src/DeveloperGeniue.CLI/Program.cs
+++ b/src/DeveloperGeniue.CLI/Program.cs
@@ -11,7 +11,8 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
-        IConfigurationService config = new DatabaseConfigurationService();
+        var passphrase = Environment.GetEnvironmentVariable("GENIUE_PASSPHRASE");
+        IConfigurationService config = new DatabaseConfigurationService(null, passphrase);
         var lang = new LanguageService(config);
         await lang.InitializeAsync();
         Console.WriteLine($"Using language: {lang.CurrentLanguage}");

--- a/src/DeveloperGeniue.Core/CryptoHelper.cs
+++ b/src/DeveloperGeniue.Core/CryptoHelper.cs
@@ -1,0 +1,59 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DeveloperGeniue.Core;
+
+public static class CryptoHelper
+{
+    public static string Encrypt(string plaintext, string? passphrase)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var bytes = Encoding.UTF8.GetBytes(plaintext);
+            var encrypted = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
+            return Convert.ToBase64String(encrypted);
+        }
+
+        if (string.IsNullOrEmpty(passphrase))
+            throw new InvalidOperationException("Passphrase required for encryption on this platform.");
+
+        using var aes = Aes.Create();
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var pdb = new Rfc2898DeriveBytes(passphrase, salt, 10000, HashAlgorithmName.SHA256);
+        aes.Key = pdb.GetBytes(32);
+        aes.IV = pdb.GetBytes(16);
+
+        using var ms = new MemoryStream();
+        ms.Write(salt, 0, salt.Length);
+        using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        using (var sw = new StreamWriter(cs, Encoding.UTF8))
+        {
+            sw.Write(plaintext);
+        }
+        return Convert.ToBase64String(ms.ToArray());
+    }
+
+    public static string Decrypt(string encrypted, string? passphrase)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var bytes = Convert.FromBase64String(encrypted);
+            var decrypted = ProtectedData.Unprotect(bytes, null, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(decrypted);
+        }
+
+        if (string.IsNullOrEmpty(passphrase))
+            throw new InvalidOperationException("Passphrase required for decryption on this platform.");
+
+        var data = Convert.FromBase64String(encrypted);
+        var salt = data.AsSpan(0, 16).ToArray();
+        using var aes = Aes.Create();
+        var pdb = new Rfc2898DeriveBytes(passphrase, salt, 10000, HashAlgorithmName.SHA256);
+        aes.Key = pdb.GetBytes(32);
+        aes.IV = pdb.GetBytes(16);
+        using var ms = new MemoryStream(data, 16, data.Length - 16);
+        using var cs = new CryptoStream(ms, aes.CreateDecryptor(), CryptoStreamMode.Read);
+        using var sr = new StreamReader(cs, Encoding.UTF8);
+        return sr.ReadToEnd();
+    }
+}

--- a/src/DeveloperGeniue.Core/DatabaseConfigurationService.cs
+++ b/src/DeveloperGeniue.Core/DatabaseConfigurationService.cs
@@ -9,11 +9,13 @@ namespace DeveloperGeniue.Core;
 public class DatabaseConfigurationService : IConfigurationService
 {
     private readonly string _connectionString;
+    private readonly string? _passphrase;
 
-    public DatabaseConfigurationService(string? databasePath = null)
+    public DatabaseConfigurationService(string? databasePath = null, string? passphrase = null)
     {
         var path = databasePath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "geniue_config.db");
         _connectionString = $"Data Source={path}";
+        _passphrase = passphrase;
         EnsureDatabase();
     }
 
@@ -60,7 +62,16 @@ public class DatabaseConfigurationService : IConfigurationService
 
     public async Task SetSettingAsync<T>(string key, T value)
     {
-        var json = JsonSerializer.Serialize(value);
+        string json;
+        if (key.EndsWith("ApiKey", StringComparison.OrdinalIgnoreCase) && value is string str)
+        {
+            var encrypted = CryptoHelper.Encrypt(str, _passphrase);
+            json = JsonSerializer.Serialize(encrypted);
+        }
+        else
+        {
+            json = JsonSerializer.Serialize(value);
+        }
         using var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync();
         using var cmd = connection.CreateCommand();

--- a/tests/DeveloperGeniue.Tests/ApiKeyEncryptionTests.cs
+++ b/tests/DeveloperGeniue.Tests/ApiKeyEncryptionTests.cs
@@ -1,0 +1,36 @@
+using DeveloperGeniue.Core;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace DeveloperGeniue.Tests;
+
+public class ApiKeyEncryptionTests
+{
+    [Fact]
+    public async Task FileServiceEncryptsApiKeys()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var service = new ConfigurationService(path, "pass");
+        await service.SetSettingAsync("MyServiceApiKey", "secret");
+        var json = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("secret", json);
+        var decrypted = CryptoHelper.Decrypt(await service.GetSettingAsync<string>("MyServiceApiKey")!, "pass");
+        Assert.Equal("secret", decrypted);
+        File.Delete(path);
+    }
+
+    [Fact]
+    public async Task DatabaseServiceEncryptsApiKeys()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var service = new DatabaseConfigurationService(db, "pass");
+        await service.SetSettingAsync("MyServiceApiKey", "secret");
+        service = new DatabaseConfigurationService(db, "pass");
+        var val = await service.GetSettingAsync<string>("MyServiceApiKey");
+        Assert.NotEqual("secret", val);
+        var decrypted = CryptoHelper.Decrypt(val!, "pass");
+        Assert.Equal("secret", decrypted);
+        File.Delete(db);
+    }
+}

--- a/tests/DeveloperGeniue.Tests/ClaudeAIClientTests.cs
+++ b/tests/DeveloperGeniue.Tests/ClaudeAIClientTests.cs
@@ -30,10 +30,10 @@ public class ClaudeAIClientTests
     public async Task UsesApiKeyFromConfiguration()
     {
         var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        var config = new ConfigurationService(file);
+        var config = new ConfigurationService(file, "pass");
         await config.SetSettingAsync("ClaudeApiKey", "abc");
         var handler = new Handler();
-        var client = new ClaudeAIClient(config, new HttpClient(handler));
+        var client = new ClaudeAIClient(config, new HttpClient(handler), "pass");
 
         var result = await client.GetCompletionAsync(new AIRequest("hi", "Claude"));
 

--- a/tests/DeveloperGeniue.Tests/OpenAIClientTests.cs
+++ b/tests/DeveloperGeniue.Tests/OpenAIClientTests.cs
@@ -30,10 +30,10 @@ public class OpenAIClientTests
     public async Task UsesApiKeyFromConfiguration()
     {
         var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        var config = new ConfigurationService(file);
+        var config = new ConfigurationService(file, "pass");
         await config.SetSettingAsync("OpenAIApiKey", "abc");
         var handler = new Handler();
-        var client = new OpenAIClient(config, new HttpClient(handler));
+        var client = new OpenAIClient(config, new HttpClient(handler), "pass");
 
         var result = await client.GetCompletionAsync(new AIRequest("hi", "OpenAI"));
 


### PR DESCRIPTION
## Summary
- encrypt API key values on save
- provide CryptoHelper for DPAPI/AES support
- decrypt keys before sending in API clients
- add passphrase handling in CLI host
- document encrypted storage in README
- test encryption behavior

## Testing
- `dotnet restore DeveloperGeniue.sln` *(fails: NU1605 package downgrade)*
- `dotnet build DeveloperGeniue.sln --no-restore` *(fails: NU1605 package downgrade)*

------
https://chatgpt.com/codex/tasks/task_e_684d107de8748332858990827c4643d4