### PR TITLE
Update tests for cross-platform fake dotnet

### DIFF
--- a/tests/DeveloperGeniue.Tests/BuildManagerAsyncTests.cs
+++ b/tests/DeveloperGeniue.Tests/BuildManagerAsyncTests.cs
@@ -1,4 +1,5 @@
 using DeveloperGeniue.Core;
+using System.Runtime.InteropServices;
 
 namespace DeveloperGeniue.Tests;
 
@@ -7,17 +8,14 @@ public class BuildManagerAsyncTests
     [Fact]
     public async Task BuildWithCancellationTokenRuns()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        var fake = Path.Combine(tempDir, "dotnet");
-        await File.WriteAllTextAsync(fake, "#!/bin/sh\necho building $@\n");
-        System.Diagnostics.Process.Start("chmod", $"+x {fake}").WaitForExit();
-        var oldPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+        var isWin = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var lines = isWin
+            ? new[] { "@echo off", "echo building %*" }
+            : new[] { "echo building $@" };
+        var (tempDir, oldPath) = TestHelpers.CreateFakeDotnet(lines);
         var bm = new BuildManager();
         var result = await bm.BuildProjectAsync("proj.csproj", CancellationToken.None);
-        Environment.SetEnvironmentVariable("PATH", oldPath);
-        Directory.Delete(tempDir, true);
+        TestHelpers.CleanupFakeDotnet(tempDir, oldPath);
         Assert.True(result.Success);
     }
 }

--- a/tests/DeveloperGeniue.Tests/TestHelpers.cs
+++ b/tests/DeveloperGeniue.Tests/TestHelpers.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+namespace DeveloperGeniue.Tests;
+
+internal static class TestHelpers
+{
+    public static (string TempDir, string OldPath) CreateFakeDotnet(params string[] scriptLines)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var fileName = isWindows ? "dotnet.cmd" : "dotnet";
+        var newline = isWindows ? "\r\n" : "\n";
+        var script = string.Join(newline, scriptLines) + newline;
+        if (!isWindows)
+        {
+            script = "#!/bin/sh" + newline + script;
+        }
+        var path = Path.Combine(tempDir, fileName);
+        File.WriteAllText(path, script);
+        if (!isWindows)
+        {
+            Process.Start("chmod", $"+x {path}").WaitForExit();
+        }
+        var oldPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+        return (tempDir, oldPath);
+    }
+
+    public static void CleanupFakeDotnet(string tempDir, string oldPath)
+    {
+        Environment.SetEnvironmentVariable("PATH", oldPath);
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
+    }
+}

--- a/tests/DeveloperGeniue.Tests/TestManagerTests.cs
+++ b/tests/DeveloperGeniue.Tests/TestManagerTests.cs
@@ -1,4 +1,5 @@
 using DeveloperGeniue.Core;
+using System.Runtime.InteropServices;
 
 namespace DeveloperGeniue.Tests;
 
@@ -7,20 +8,33 @@ public class TestManagerTests
     [Fact]
     public async Task TestResultsAreParsed()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        var fake = Path.Combine(tempDir, "dotnet");
-        var script = "#!/bin/sh\necho 'Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 1 ms'\necho 'Test Run Successful.'\necho 'Test execution time: 0.1'\n";
-        await File.WriteAllTextAsync(fake, script);
-        System.Diagnostics.Process.Start("chmod", $"+x {fake}").WaitForExit();
-        var oldPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + oldPath);
+        var isWin = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        string[] lines;
+        if (isWin)
+        {
+            lines = new[]
+            {
+                "@echo off",
+                "echo Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 1 ms",
+                "echo Test Run Successful.",
+                "echo Test execution time: 0.1"
+            };
+        }
+        else
+        {
+            lines = new[]
+            {
+                "echo 'Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 1 ms'",
+                "echo 'Test Run Successful.'",
+                "echo 'Test execution time: 0.1'"
+            };
+        }
+        var (tempDir, oldPath) = TestHelpers.CreateFakeDotnet(lines);
 
         var tm = new TestManager();
         var result = await tm.RunTestsAsync("proj.csproj");
 
-        Environment.SetEnvironmentVariable("PATH", oldPath);
-        Directory.Delete(tempDir, true);
+        TestHelpers.CleanupFakeDotnet(tempDir, oldPath);
 
         Assert.True(result.Success);
         Assert.Equal(1, result.TotalTests);


### PR DESCRIPTION
## Summary
- add shared TestHelpers for creating fake dotnet commands
- update BuildManager and TestManager unit tests to use TestHelpers
- generate `.cmd` files on Windows or shell scripts on Unix
- ensure PATH cleanup uses helper

## Testing
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj -v minimal` *(fails: NU1605 package downgrade)*

------
https://chatgpt.com/codex/tasks/task_e_684d1080fc488332b4b045cccaac8eee