### PR TITLE
Improve async project loading

### DIFF
--- a/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
+++ b/src/DeveloperGeniue.Core/DeveloperGeniue.Core.csproj
@@ -8,8 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>
 

--- a/tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj
+++ b/tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>

--- a/tests/DeveloperGeniue.Tests/LoggingTests.cs
+++ b/tests/DeveloperGeniue.Tests/LoggingTests.cs
@@ -2,6 +2,7 @@ using DeveloperGeniue.Core;
 using Serilog;
 using Serilog.Events;
 using Serilog.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace DeveloperGeniue.Tests;
 

--- a/tests/DeveloperGeniue.Tests/ProjectManagerAsyncTests.cs
+++ b/tests/DeveloperGeniue.Tests/ProjectManagerAsyncTests.cs
@@ -16,4 +16,23 @@ public class ProjectManagerAsyncTests
         Directory.Delete(tempDir, true);
         Assert.Equal(sync, asyncResult.ToList());
     }
+
+    [Fact]
+    public async Task GetProjectFilesAsyncReadsContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var file = Path.Combine(tempDir, "Test.csproj");
+        var content = "<Project/>";
+        await File.WriteAllTextAsync(file, content);
+
+        var pm = new ProjectManager();
+        var result = await pm.GetProjectFilesAsync(tempDir, CancellationToken.None);
+
+        Directory.Delete(tempDir, true);
+
+        var codeFile = Assert.Single(result);
+        Assert.Equal(file, codeFile.Path);
+        Assert.Equal(content, codeFile.Content);
+    }
 }


### PR DESCRIPTION
## Summary
- update logging packages to avoid downgrade errors
- add missing Serilog sink references
- fix logging tests build
- add async test for reading project files

## Testing
- `dotnet restore`
- `dotnet test tests/DeveloperGeniue.Tests/DeveloperGeniue.Tests.csproj -v minimal` *(fails: LoggerSinkConfiguration extension methods not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d10800f788332ab05674a3e0ad830